### PR TITLE
I2c streaming

### DIFF
--- a/os/dev/i2c-dev-stream.c
+++ b/os/dev/i2c-dev-stream.c
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2017, RISE SICS.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ *
+ */
+
+/**
+ * \file
+ *         i2c streaming
+ * \author
+ *         Niklas Wirström <niklas.wirstrom@ri.se>
+ *
+ */
+
+#include "i2c-dev-stream.h"
+
+#include <stdio.h>
+
+/*---------------------------------------------------------------------------*/
+
+/*Read register on device, writes to stream->buffer, calls stream->handler every stream->length byte
+ * The i2c_chunk_handler is assumed to return the following:
+ * I2C_STREAM_LAST_CHUNK -  before last chunk will is read
+ * I2C_STREAM_END        -  when last chunk has been read
+ * I2C_STREAM_CONTINUE   -  otherwise
+ */
+i2c_dev_status_t
+i2c_dev_read_register_stream(i2c_device_t *dev, uint8_t reg, i2c_dev_stream_t *stream)
+{
+  i2c_dev_status_t status;
+  i2c_dev_stream_state_t state = I2C_STREAM_START;
+
+  status = i2c_arch_write(dev, &reg, 1, 1, 0);
+  if(status != I2C_DEV_STATUS_OK) {
+    return status;
+  }
+
+  status = i2c_arch_read(dev, (uint8_t *)stream->buffer, stream->length, 1, 0);
+  while(1) {
+    if(status != I2C_DEV_STATUS_OK) {
+      return status;
+    }
+    state = stream->handler(stream);
+
+    if(state == I2C_STREAM_LAST_CHUNK) {
+      break;
+    }
+    status = i2c_arch_read(dev, (uint8_t *)stream->buffer, stream->length, 0, 0);
+  }
+  status = i2c_arch_read(dev, (uint8_t *)stream->buffer, stream->length, 0, 1);
+  if(status != I2C_DEV_STATUS_OK) {
+    return status;
+  }
+  state = stream->handler(stream);
+
+  return status;
+}
+/*---------------------------------------------------------------------------*/

--- a/os/dev/i2c-dev-stream.h
+++ b/os/dev/i2c-dev-stream.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2017, RISE SICS.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ *
+ */
+
+/**
+ * \file
+ *         i2c streaming
+ * \author
+ *         Niklas Wirström <niklas.wirstrom@ri.se>
+ *
+ */
+
+#ifndef I2C_DEV_STREAM_H_
+#define I2C_DEV_STREAM_H_
+
+#include "dev/i2c-dev.h"
+
+typedef enum {
+  I2C_STREAM_START,
+  I2C_STREAM_LAST_CHUNK,
+  I2C_STREAM_CONTINUE,
+  I2C_STREAM_END
+} i2c_dev_stream_state_t;
+
+typedef struct _chunk i2c_dev_stream_t;
+typedef i2c_dev_stream_state_t (*i2c_chunk_handler)(i2c_dev_stream_t *);
+
+struct _chunk {
+  volatile int length;
+  volatile uint8_t *buffer;
+  volatile i2c_chunk_handler handler;
+};
+
+i2c_dev_status_t i2c_dev_read_register_stream(i2c_device_t *dev, uint8_t reg, i2c_dev_stream_t *stream);
+
+#endif /* I2C_DEV_STREAM_H_ */

--- a/os/dev/i2c-dev.c
+++ b/os/dev/i2c-dev.c
@@ -104,16 +104,16 @@ i2c_dev_write_byte(i2c_device_t *dev, uint8_t data)
   if(!i2c_dev_has_bus(dev)) {
     return I2C_DEV_STATUS_BUS_LOCKED;
   }
-  return i2c_arch_write(dev, &data, 1);
+  return i2c_arch_write(dev, &data, 1, 1, 1);
 }
 /*---------------------------------------------------------------------------*/
 i2c_dev_status_t
-i2c_dev_write(i2c_device_t *dev, const uint8_t *data, int size)
+i2c_dev_write(i2c_device_t *dev, const uint8_t *data, int size, int start, int stop)
 {
   if(!i2c_dev_has_bus(dev)) {
     return I2C_DEV_STATUS_BUS_LOCKED;
   }
-  return i2c_arch_write(dev, data, size);
+  return i2c_arch_write(dev, data, size, start, stop);
 }
 /*---------------------------------------------------------------------------*/
 i2c_dev_status_t
@@ -122,16 +122,16 @@ i2c_dev_read_byte(i2c_device_t *dev, uint8_t *data)
   if(!i2c_dev_has_bus(dev)) {
     return I2C_DEV_STATUS_BUS_LOCKED;
   }
-  return i2c_arch_read(dev, data, 1);
+  return i2c_arch_read(dev, data, 1, 1, 1);
 }
 /*---------------------------------------------------------------------------*/
 i2c_dev_status_t
-i2c_dev_read(i2c_device_t *dev, uint8_t *data, int size)
+i2c_dev_read(i2c_device_t *dev, uint8_t *data, int size, int start, int stop)
 {
   if(!i2c_dev_has_bus(dev)) {
     return I2C_DEV_STATUS_BUS_LOCKED;
   }
-  return i2c_arch_read(dev, data, size);
+  return i2c_arch_read(dev, data, size, start, stop);
 }
 /*---------------------------------------------------------------------------*/
 /* Read a register - e.g. first write a data byte to select register to read from, then read */
@@ -140,12 +140,12 @@ i2c_dev_read_register(i2c_device_t *dev, uint8_t reg, uint8_t *data, int size)
 {
   i2c_dev_status_t status;
   /* write the register first */
-  status = i2c_dev_write_byte(dev, reg);
+  status = i2c_dev_write(dev, &reg, 1, 1, 0);
   if(status != I2C_DEV_STATUS_OK) {
     return status;
   }
   /* then read the value */
-  status = i2c_dev_read(dev, data, size);
+  status = i2c_dev_read(dev, data, size, 1, 1);
   if(status != I2C_DEV_STATUS_OK) {
     return status;
   }
@@ -163,7 +163,7 @@ i2c_dev_write_register(i2c_device_t *dev, uint8_t reg, uint8_t data)
   buffer[0] = reg;
   buffer[1] = data;
 
-  status = i2c_dev_write(dev, buffer, 2);
+  status = i2c_dev_write(dev, buffer, 2, 1, 1);
   if(status != I2C_DEV_STATUS_OK) {
     return status;
   }
@@ -182,7 +182,7 @@ i2c_dev_write_register_buf(i2c_device_t *dev, uint8_t reg, const uint8_t *data, 
   buffer[0] = reg;
   memcpy(&buffer[1], data, size);
 
-  status = i2c_dev_write(dev, buffer, size + 1);
+  status = i2c_dev_write(dev, buffer, size + 1, 1, 1);
   if(status != I2C_DEV_STATUS_OK) {
     return status;
   }

--- a/os/dev/i2c-dev.h
+++ b/os/dev/i2c-dev.h
@@ -78,8 +78,8 @@ i2c_dev_status_t i2c_dev_restart_timeout(i2c_device_t *dev);
 i2c_dev_status_t i2c_dev_write_byte(i2c_device_t *dev, uint8_t data);
 i2c_dev_status_t i2c_dev_read_byte(i2c_device_t *dev, uint8_t *data);
 i2c_dev_status_t i2c_dev_write(i2c_device_t *dev, const uint8_t *data,
-                               int size);
-i2c_dev_status_t i2c_dev_read(i2c_device_t *dev, uint8_t *data, int size);
+                               int size, int start, int stop);
+i2c_dev_status_t i2c_dev_read(i2c_device_t *dev, uint8_t *data, int size, int start, int stop);
 i2c_dev_status_t i2c_dev_stop(i2c_device_t *dev);
 
 i2c_dev_status_t i2c_dev_write_register(i2c_device_t *dev,
@@ -94,9 +94,8 @@ i2c_dev_status_t i2c_arch_lock(i2c_device_t *dev);
 i2c_dev_status_t i2c_arch_unlock(i2c_device_t *dev);
 i2c_dev_status_t i2c_arch_restart_timeout(i2c_device_t *dev);
 
-i2c_dev_status_t i2c_arch_read(i2c_device_t *dev, uint8_t *data, int len);
-i2c_dev_status_t i2c_arch_write(i2c_device_t *dev,
-                                const uint8_t *data, int len);
+i2c_dev_status_t i2c_arch_read(i2c_device_t *dev, uint8_t* buffer, int length, uint8_t start, uint8_t stop);
+i2c_dev_status_t i2c_arch_write(i2c_device_t *dev, const uint8_t* buffer, int length, uint8_t start, uint8_t stop);
 i2c_dev_status_t i2c_arch_stop(i2c_device_t *dev);
 
 #endif /* I2C_DEV_H_ */


### PR DESCRIPTION
Minimal streaming API for I2C.
Modifies i2c_arch_read, and i2c_arch_write from the I2C API, so that it allows for reading and writing with or without the I2C start and stop bits .

Adds function i2c_dev_status_t i2c_dev_read_register_stream(i2c_device_t *dev, uint8_t reg, i2c_dev_stream_t *stream) which reads register on device, writes to stream->buffer, calls stream->handler every stream->length byte.

The i2c_chunk_handler is assumed to return the following:
I2C_STREAM_LAST_CHUNK -  before last chunk will is read 
I2C_STREAM_END        -           when last chunk has been read
I2C_STREAM_CONTINUE   -    otherwise


